### PR TITLE
Heroku: changes for Cedar stack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,12 @@ source 'https://rubygems.org'
 gem 'haml'
 gem 'sequel'
 gem 'sinatra'
-gem 'sqlite3'
 gem 'twitter'
+
+group :development, :test do
+  gem 'sqlite3'
+end
+
+group :production do
+  gem 'pg'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
+gem 'dalli'
 gem 'haml'
+gem 'rack-cache'
 gem 'sequel'
 gem 'sinatra'
 gem 'twitter'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'dalli'
 gem 'haml'
+gem 'puma'
 gem 'rack-cache'
 gem 'sequel'
 gem 'sinatra'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     addressable (2.3.5)
     atomic (1.1.14)
     buftok (0.2.0)
+    dalli (2.7.2)
     descendants_tracker (0.0.3)
     equalizer (0.0.9)
     faraday (0.9.0)
@@ -20,6 +21,8 @@ GEM
     naught (1.0.0)
     pg (0.18.1)
     rack (1.5.2)
+    rack-cache (1.2)
+      rack (>= 0.4)
     rack-protection (1.5.2)
       rack
     sequel (4.6.0)
@@ -49,8 +52,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  dalli
   haml
   pg
+  rack-cache
   sequel
   sinatra
   sqlite3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
       thread_safe (~> 0.1.3)
     multipart-post (2.0.0)
     naught (1.0.0)
+    pg (0.18.1)
     rack (1.5.2)
     rack-protection (1.5.2)
       rack
@@ -49,6 +50,7 @@ PLATFORMS
 
 DEPENDENCIES
   haml
+  pg
   sequel
   sinatra
   sqlite3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,9 @@ GEM
     multipart-post (2.0.0)
     naught (1.0.0)
     pg (0.18.1)
-    rack (1.5.2)
+    puma (2.11.1)
+      rack (>= 1.1, < 2.0)
+    rack (1.6.0)
     rack-cache (1.2)
       rack (>= 0.4)
     rack-protection (1.5.2)
@@ -55,6 +57,7 @@ DEPENDENCIES
   dalli
   haml
   pg
+  puma
   rack-cache
   sequel
   sinatra

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec rackup --port $PORT
+web: bundle exec puma -C puma.rb

--- a/app.rb
+++ b/app.rb
@@ -9,6 +9,7 @@ DB.create_table? :tweets do
   primary_key :id
   String :content
   BigNum :twitter_id, :type => :bigint
+  unique [:content, :twitter_id]
 end
 tweets = DB[:tweets]
 

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,15 @@
-require "sinatra"
+require 'dalli'
+require 'rack/cache'
+require 'sinatra'
 
-root_dir = File.dirname(__FILE__)
+if memcachier_servers = ENV["MEMCACHIER_SERVERS"]
+  cache = Dalli::Client.new memcachier_servers.split(','), {
+    username: ENV['MEMCACHIER_USERNAME'],
+    password: ENV['MEMCACHIER_PASSWORD'],
+  }
+  use Rack::Cache, verbose: true, metastore: cache, entitystore: cache
+end
 
-require File.join(root_dir, "app")
+require File.expand_path('../app', __FILE__)
+
 run Sinatra::Application

--- a/puma.rb
+++ b/puma.rb
@@ -1,0 +1,9 @@
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+threads_count = Integer(ENV['MAX_THREADS'] || 5)
+threads threads_count, threads_count
+
+preload_app!
+
+rackup      DefaultRackup
+port        ENV['PORT']     || 3000
+environment ENV['RACK_ENV'] || 'development'


### PR DESCRIPTION
:information_desk_person: These changes should be enough to get the application deployed on Heroku's Cedar stack.

They:
- enable the `pg` gem for PostgreSQL persistence; and
- de-duplicate the tweets being stored by adding a unique constraint on `content` and `twitter_id`
- use `Rack::Cache` and the `Memcachier` addon for frontside caching
- add and configure the app to use [`Puma`](https://github.com/puma/puma) as the webserver

See https://serene-citadel-8188.herokuapp.com/ for a demo of this branch. :tada: 
